### PR TITLE
fix: sentry environment

### DIFF
--- a/inc/head.php
+++ b/inc/head.php
@@ -59,6 +59,7 @@
   <script>
     Sentry.init({
       dsn: "https://11f513ea178d438e8f12836de7baa87d@sentry.keyman.com/10",
+      environment: location.host.match(/\.local$/) ? 'development' : location.host.match(/(^|\.)keyman-staging\.com$/) ? 'staging' : 'production',
     });
   </script>
 


### PR DESCRIPTION
Note: while keymanweb.com does not currently have a staging environment, I have left the environment string for sentry the same as for the other sites as it doesn't hurt and reduces maintenance cost.