### PR TITLE
fix: Improve load performance and stability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 cdn/deploy
 
 /vendor/
+.data/

--- a/App_Data/jobs/triggered/cache_keyboards/run.php
+++ b/App_Data/jobs/triggered/cache_keyboards/run.php
@@ -1,0 +1,3 @@
+<?php
+  $do_cache = true;
+  require_once __DIR__ . '/../../../../prog/keyboards.php';

--- a/App_Data/jobs/triggered/cache_keyboards/settings.job
+++ b/App_Data/jobs/triggered/cache_keyboards/settings.job
@@ -1,0 +1,4 @@
+{
+  "schedule": "0 */5 * * * *",
+  "is_in_place": true
+}

--- a/inc/servervars.php
+++ b/inc/servervars.php
@@ -15,8 +15,12 @@
   Notes:
   History:          17 Oct 2009 - mcdurdin - Alter help base dir
 */
+
   require_once __DIR__ . '/../vendor/autoload.php';
+  require_once __DIR__ . '/../_include/autoload.php';
   require_once __DIR__ . '/../_common/KeymanSentry.php';
+
+  use \Keyman\Site\Common\KeymanHosts;
 
   const SENTRY_DSN = 'https://11f513ea178d438e8f12836de7baa87d@sentry.keyman.com/10';
   \Keyman\Site\Common\KeymanSentry::init(SENTRY_DSN);
@@ -31,7 +35,10 @@
 
   function GetHostSuffix() {
     global $site_url;
+    if(!isset($_SERVER['SERVER_NAME'])) return '';
+
     $name = $_SERVER['SERVER_NAME'];
+
     if(stripos($name, $site_url.'.') == 0) {
       return substr($name, strlen($site_url), 1024);
     }
@@ -66,6 +73,26 @@
       return "/cdn/deploy{$cdn['/'.$file]}";
     }
     return "/cdn/dev/{$file}";
+  }
+
+
+  function get_major_version($version) {
+    return preg_replace('/^(\\d+)\\.(\\d+).*$/', '$1.$2', $version);
+  }
+
+  function get_keymanweb_version($tier) {
+    $json = @file_get_contents(KeymanHosts::Instance()->r_keymanweb_com . "/code/get-version/web/$tier");
+    if($json) {
+      $json = json_decode($json);
+    }
+
+    if($json && property_exists($json, 'version')) {
+      $version = $json->version;
+    } else {
+      // If the get-version API fails, we'll use the latest known version
+      $version = "13.0.109";
+    }
+    return $version;
   }
 
 ?>

--- a/prog/keyboards.php
+++ b/prog/keyboards.php
@@ -1,0 +1,88 @@
+<?php
+  require_once __DIR__ . '/../inc/servervars.php';
+
+  use Keyman\Site\Common\KeymanHosts;
+
+  header('Content-Type: application/javascript; charset=utf-8');
+  header('Cache-Control: public, max-age=300');
+
+  $tiers = array('alpha','beta','stable');
+
+  if(isset($_REQUEST['cache']) || isset($do_cache)) {
+    // This is set for the web job that runs every
+    // five minutes
+    cache_keyboards($tiers);
+    exit;
+  }
+
+  if(isset($_REQUEST['tier']) && in_array($_REQUEST['tier'], $tiers, TRUE)) {
+    $tier = $_REQUEST['tier'];
+  } else {
+    $tier = 'stable';
+  }
+
+  if(isset($_REQUEST['version']) && preg_match('/^\\d+\\.\\d+$/', $_REQUEST['version'])) {
+    $version = $_REQUEST['version'];
+  } else {
+    $version = get_keymanweb_version($tier);
+  }
+  $version = get_major_version($version);
+
+  // We will cache this result for 5 minutes locally and allow proxies and clients to cache also for that
+  // amount of time, so that we get fast loads.
+
+  define('CACHED_KEYBOARDS', get_cache_file($version));
+
+  $cache = false;
+  $current_time = time();
+  $expire_time = 300; // 5 minutes
+  $cache_detail = '';
+
+  if(file_exists(CACHED_KEYBOARDS) && $current_time - $expire_time < filemtime(CACHED_KEYBOARDS)) {
+    $cache_detail = 'cached ' . date('c', filemtime(CACHED_KEYBOARDS));
+    $cache = @file_get_contents(CACHED_KEYBOARDS);
+  }
+
+  if($cache === false) {
+    $cache_detail = 'cache expired or empty, retrieved from cloud';
+    $cache = @file_get_contents(get_cache_url($version));
+    if($cache === false) {
+      die('// unable to load keyboards from cache or from cloud');
+    }
+  }
+
+  function get_cache_url($version) {
+    return KeymanHosts::Instance()->api_keyman_com ."/cloud/4.0/keyboards?jsonp=keyman.register&languageidtype=bcp47&version=$version&timerid=1"    ;
+  }
+
+  function get_cache_file($version) {
+    return __DIR__ . "/../.data/cached-keyboards-$version.js";
+  }
+  ///
+  /// Caches keyboard registrations for each tier to relevant cache file
+  /// Note that at certain times, alpha+beta may be same version, or
+  /// beta+stable may be same version. We're not going to worry about
+  /// writing the file twice; it won't really hurt.
+  ///
+  function cache_keyboards($tiers) {
+    // Recache alpha beta and stable versions
+
+    @mkdir(__DIR__ . "/../.data");
+
+    foreach($tiers as $tier) {
+      $version = get_major_version(get_keymanweb_version($tier));
+      $cache_file = get_cache_file($version);
+      $cache_url = get_cache_url($version);
+
+      echo "Caching $cache_url to $cache_file\n";
+      $cache = @file_get_contents($cache_url);
+      if($cache !== false) {
+        file_put_contents($cache_file, $cache);
+      }
+    }
+  }
+?>
+/* tier <?= $tier ?>, version <?= $version ?>, <?= $cache_detail ?> */
+function addKeyboards() {
+  <?= $cache ?>
+}


### PR DESCRIPTION
1. (inc/head.php, inc/servervars.php, prog/keyboards.php) Makes keymanweb.com responsible for loading the cloud keyboards and making them available to keymanweb.

2. (.gitignore, App_Data/*, prog/keyboards.php) Adds a cache for the cloud keyboards that is refreshed on the back-end every five minutes, and caches the catalog both in cloudflare and in user browser in the meantime.

3. Fixes #17 by moving responsibility for activating keyboard to this website, and tidying up interaction with the cookie.

4. Refactors a few pieces of the Javascript code to reduce the complexity and allow sharing of code with keyboards.php

5. Ensures the message textarea is focused after the keyboard loads.

6. Cleans up a variety of old code (move js loads back inline as this is no longer a real performance blocker).

Relates to keymanapp/keyman#4304.