### PR TITLE
chore: automatically use web's beta during beta cycles

### DIFF
--- a/inc/head.php
+++ b/inc/head.php
@@ -17,10 +17,7 @@
     $tier = $_REQUEST['tier'];
   } else {
     // Select the 'stable' version unless we're in a beta cycle.
-    $beta_version   = get_major_version($kmw_builds['beta']);
-    $stable_version = get_major_version($kmw_builds['stable']);
-
-    if(version_compare($stable_version, $beta_version) < 0) {
+    if(version_compare($kmw_builds['stable'], $kmw_builds['beta']) < 0) {
       $tier = 'beta';
     } else {
       $tier = 'stable';

--- a/inc/head.php
+++ b/inc/head.php
@@ -2,18 +2,34 @@
   session_start();
   require_once('servervars.php');
 
-  if(isset($_REQUEST['tier']) &&
-      in_array($_REQUEST['tier'], array('alpha','beta','stable'), TRUE)) {
-    $tier = $_REQUEST['tier'];
-  } else {
-    $tier = 'stable';
-  }
+  $kmw_tiers = array('alpha', 'beta', 'stable');
+  $kmw_builds = array();
 
   if(isset($_REQUEST['version']) && preg_match('/^(\d+)\.(\d+)\.(\d+)$/', $_REQUEST['version'])) {
     $kmwbuild = $_REQUEST['version'];
   } else {
-    $kmwbuild = get_keymanweb_version($tier);
+    foreach ($kmw_tiers as $index => $possible_tier) {
+      $kmw_builds[$possible_tier] = get_keymanweb_version($possible_tier);
+    }
   }
+
+  if(isset($_REQUEST['tier']) &&
+      in_array($_REQUEST['tier'], array('alpha','beta','stable'), TRUE)) {
+    $tier = $_REQUEST['tier'];
+  } else {
+    // Select the 'stable' version unless we're in a beta cycle.
+    $beta_version   = get_major_version($kmw_builds['beta']);
+    $stable_version = get_major_version($kmw_builds['stable']);
+
+    if($stable_version < $beta_version) {
+      $tier = 'beta';
+    } else {
+      $tier = 'stable';
+    }
+    $tier = 'stable';
+  }
+
+  $kmwbuild = $kmw_builds[$tier];
   $version = get_major_version($kmwbuild);
 ?>
 <!DOCTYPE html>

--- a/inc/head.php
+++ b/inc/head.php
@@ -3,28 +3,32 @@
   require_once('servervars.php');
 
   $kmw_tiers = array('alpha', 'beta', 'stable');
-  $kmw_builds = array();
 
   if(isset($_REQUEST['version']) && preg_match('/^(\d+)\.(\d+)\.(\d+)$/', $_REQUEST['version'])) {
     $kmwbuild = $_REQUEST['version'];
+    $tier = 'stable';
   } else {
-    foreach ($kmw_tiers as $possible_tier) {
-      $kmw_builds[$possible_tier] = get_keymanweb_version($possible_tier);
-    }
-  }
+    // Used to enable the release-tier selection code below.
+    // For general usage, we recommend `get_keymanweb_version($tier)` instead.
+    $kmw_builds = get_keymanweb_versions();
 
-  if(isset($_REQUEST['tier']) && in_array($_REQUEST['tier'], $kmw_tiers, TRUE)) {
-    $tier = $_REQUEST['tier'];
-  } else {
-    // Select the 'stable' version unless we're in a beta cycle.
-    if(version_compare($kmw_builds['stable'], $kmw_builds['beta']) < 0) {
-      $tier = 'beta';
+    if(isset($_REQUEST['tier']) && in_array($_REQUEST['tier'], $kmw_tiers, TRUE)) {
+      $tier = $_REQUEST['tier'];
     } else {
-      $tier = 'stable';
+      // Selects the 'stable' version unless we're in a beta cycle.
+      //
+      // Note:  if API calls fail to retrieve proper version data,
+      //        the return will be 0 due to equal fallback versions.
+      //        Net result: selection of the 'stable' tier.
+      if(version_compare($kmw_builds['stable'], $kmw_builds['beta']) < 0) {
+        $tier = 'beta';
+      } else {
+        $tier = 'stable';
+      }
     }
-  }
 
-  $kmwbuild = $kmw_builds[$tier];
+    $kmwbuild = $kmw_builds[$tier];
+  }
   $version = get_major_version($kmwbuild);
 ?>
 <!DOCTYPE html>

--- a/inc/head.php
+++ b/inc/head.php
@@ -26,7 +26,6 @@
     } else {
       $tier = 'stable';
     }
-    $tier = 'stable';
   }
 
   $kmwbuild = $kmw_builds[$tier];
@@ -73,13 +72,10 @@
     return event;
   };
 
-  // We'll let 'environment' handle 'development' vs 'production' tagging.
-  let kmw_release = $version . "-" . $tier;
-
   Sentry.init({
     beforeSend: prepareEvent,
     dsn: "https://11f513ea178d438e8f12836de7baa87d@sentry.keyman.com/10",
-    release: kmw_release,
+    release: "<?=$version."-".$tier?>",
     environment: location.host.match(/\.local$/) ? 'development' : location.host.match(/(^|\.)keyman-staging\.com$/) ? 'staging' : 'production',
   });
 </script>


### PR DESCRIPTION
Fixes #19.

Makes two changes:

1. Whenever we move to a beta cycle, keymanweb.com will default to use of the new beta version.  (Detected by beta's major version exceeding stable's.)
    - Future enhancement idea:  some sort of link / note when in alpha or beta mode to ease swapping to 'stable'.  (In case users run into an issue.)
2. If KMW's `getDebugInfo` method is available, keymanweb.com will auto-tag all generated Sentry reports with its returned metadata.
    - I've also added basic version-tagging for the reports, adopting KMW's version as the site's "version".
    - I threw it in as a potential "good idea", since many of the reports really are KMW reports... but I can understand if I should revert this aspect.
    - Theis method only exists as of KMW 14.0, as it was implemented partway through the 'alpha'.