### PR TITLE
feat: add a banner for pre-release announcement

### DIFF
--- a/_common/KeymanHosts.php
+++ b/_common/KeymanHosts.php
@@ -110,7 +110,7 @@
         $this->s_keyman_com = "{$site_protocol}s.keyman.com{$site_suffix}";
         $this->api_keyman_com = "{$site_protocol}api.keyman.com{$site_suffix}";
         $this->help_keyman_com = "{$site_protocol}help.keyman.com{$site_suffix}";
-        $this->downloads_keyman_com = "https://downloads.keyman.com";
+        $this->downloads_keyman_com = "{$site_protocol}downloads.keyman.com{$site_suffix}";
         $this->keyman_com = "{$site_protocol}keyman.com{$site_suffix}";
         $this->keymanweb_com = "{$site_protocol}keymanweb.com{$site_suffix}";
         $this->r_keymanweb_com = "https://r.keymanweb.com"; /// local dev domain is usually not available

--- a/_common/KeymanHosts.php
+++ b/_common/KeymanHosts.php
@@ -110,7 +110,7 @@
         $this->s_keyman_com = "{$site_protocol}s.keyman.com{$site_suffix}";
         $this->api_keyman_com = "{$site_protocol}api.keyman.com{$site_suffix}";
         $this->help_keyman_com = "{$site_protocol}help.keyman.com{$site_suffix}";
-        $this->downloads_keyman_com = "{$site_protocol}downloads.keyman.com{$site_suffix}";
+        $this->downloads_keyman_com = "https://downloads.keyman.com";
         $this->keyman_com = "{$site_protocol}keyman.com{$site_suffix}";
         $this->keymanweb_com = "{$site_protocol}keymanweb.com{$site_suffix}";
         $this->r_keymanweb_com = "https://r.keymanweb.com"; /// local dev domain is usually not available

--- a/cdn/dev/css/kmw-desktop.css
+++ b/cdn/dev/css/kmw-desktop.css
@@ -1,6 +1,6 @@
 /* Desktop browser CSS rules */
 
-/* 
+/*
 ======================
 ==Universal Elements==
 ======================
@@ -29,13 +29,13 @@ a:hover {
 
 h3 {
   font-size:18px;
-  }		
-  
+  }
+
 p {
   font-size:13px;
   line-height:1.5em;
   }
-  
+
 header, #content, footer {
   /* width:960px; */
   margin:0px auto;
@@ -46,17 +46,17 @@ header, #content, footer {
   -webkit-border-radius: 8px;-moz-border-radius: 8px;	border-radius: 8px;
   -moz-box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.5); -webkit-box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.5); box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.5);
   }
-  
-/* 
+
+/*
 ===================
 ==Header Elements==
 ===================
-*/	
+*/
 header {
   margin-top:0px;
   height: 96px;
   }
-  
+
 header > div > img {
   width: 100%;
   display: block;
@@ -69,12 +69,26 @@ header > div > img {
   margin-left:28px;
   height:88px;
   /*width: 660px;*/
-  /*-webkit-border-radius: 0px 0px 8px 8px; -moz-border-radius: 0px 0px 8px 8px; border-radius: 0px 0px 8px 8px;*/	
+  /*-webkit-border-radius: 0px 0px 8px 8px; -moz-border-radius: 0px 0px 8px 8px; border-radius: 0px 0px 8px 8px;*/
   }
 #headerRight {
-  display: none;
+  display: block;
+  float: right;
+  text-align: right;
   }
-/* 
+
+#headerRight-beta {
+  display: block;
+  font-weight: bold;
+  color: red;
+  font-size: 16pt;
+  padding: 20px 12px 0;
+}
+
+#headerRight-link {
+  padding: 0 12px 0;
+}
+/*
 ====================
 ==Content Elements==
 ====================
@@ -83,8 +97,8 @@ header > div > img {
   min-height:375px;
   }
 
-  
-/* KMW Main App */	
+
+/* KMW Main App */
 #app {
   float:left;
   /*height:330px;*/
@@ -94,24 +108,24 @@ header > div > img {
 #KeymanWebControl {
   width:710px;
   height: 35px;
-  display:block;  
+  display:block;
   -webkit-border-radius: 8px 8px 0px 0px; -moz-border-radius: 8px 8px 0px 0px; border-radius: 8px 8px 0px 0px;
   }
-  
+
   #kmw_controls{
     border-top-left-radius: 8px;
     border-top-right-radius: 8px;
     -moz-box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.5); -webkit-box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.5); box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.5);
   }
-  
+
   #kmw_btn_osk{
     border-top-right-radius: 10px;
   }
-  
+
   #kmw_controls_start{
     border-top-left-radius: 10px;
   }
-  
+
   #exampleBox{
     min-height: 25px;
   }
@@ -130,14 +144,14 @@ header > div > img {
   min-height: 45px;
   padding-top: 5px;
 }
-  
+
 #example a{
   float: right;
   margin-right: 10px;
   position: relative;
   top: -10px;
 }
-      
+
 textarea {
   height:260px;
   width:554px;
@@ -147,17 +161,17 @@ textarea {
   font-size:16px;
   font-family:SindhiWeb,Verdana,GeezWeb,LaoWeb,TibetanWeb,MyanmarWeb,SinhalaWeb,TamilWeb,KhmerWeb,LatinWeb,OriyaWeb,EgyptianWeb !important;
   }
-    
+
 form {
   padding-right:10px;
   float:left;
-  }	
+  }
 #messageContainer {
   float:left;
   width:80%;
   }
-  
-/* KMW App Buttons */	
+
+/* KMW App Buttons */
 
 #instructions {
   margin:-1px 0px 2px;
@@ -167,10 +181,10 @@ form {
   float:right;
   padding-right:10px;
   }
-  
+
 #buttons div {
   width:120px;
-  -webkit-border-radius: 4px; -moz-border-radius: 4px; border-radius: 4px;	
+  -webkit-border-radius: 4px; -moz-border-radius: 4px; border-radius: 4px;
 	background-color: #eeeeee;
   border: 1px solid #888888;
   margin: 0px 10px;
@@ -318,30 +332,30 @@ form {
 div.links {
   cursor:pointer;
   }
-  
+
 div.linksOff {
   cursor:default !important;
-  border: 1px solid #cccccc !important;  
+  border: 1px solid #cccccc !important;
   }
-  
+
 div.linksOff * {
   color: gray;
   -moz-user-select:none;
   }
-    
+
 #tweetcount, #twitter span {
   color: #666;
   font: bold 0.8em Helvetica, Verdana, Arial, sans-serif;
   text-shadow: 0 1px 1px white;
   }
 
-  
+
 hr {
   margin: 6px 4px 6px 4px;
   }
-  
-  
-/* Aside Elements */	
+
+
+/* Aside Elements */
 aside {
   float:right;
   width:200px;
@@ -353,10 +367,10 @@ aside h3 {
   margin:0px;
   -webkit-border-radius: 8px 8px 0px 0px; -moz-border-radius: 8px 8px 0px 0px; border-radius: 8px 8px 0px 0px;
   -moz-box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.5); -webkit-box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.5); box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.5);
-  }	
+  }
 aside > div {
   margin:30px 0px 0px;
-  }	
+  }
 aside p {
   padding:10px;
   margin:0px;
@@ -365,7 +379,7 @@ aside  #learn {
   font-size:13px;
   text-align:center;
   }
-  
+
 #socialshare > .fb-like {
   margin: 10px;
   width: 77px;
@@ -411,7 +425,7 @@ aside  #learn {
   display: none;
 }
 
-/* 
+/*
 ===================
 ==Footer Elements==
 ===================
@@ -496,7 +510,7 @@ aside  #learn {
   font-family: "social-logos";
   src: url("../../fonts/social-logos.ttf");
   font-weight: normal;
-  font-style: normal; 
+  font-style: normal;
 }
 
 [data-icon]:before {
@@ -553,7 +567,7 @@ aside  #learn {
 #footer-social a#footer-community {
   padding-left: 27px;
 }
-  
+
 .subscribe{
     width: 90px;
     margin: 0px;
@@ -602,18 +616,18 @@ aside  #learn {
     margin-top: 10px;
 }
 
-/* 
+/*
 ===================
 ==Extras==
 ===================
 */
-  
+
 #fblike{
 position: absolute;
 left: 50%;
 margin-left: 320px;
   }
-  
+
 nav ul {
   list-style: none outside none;
   width:90%;
@@ -631,7 +645,7 @@ nav a {
   font-family:Tahoma;
   font-weight:bold;
   font-size:10.7px;
-  }	
+  }
 
 .messageBox {
   -webkit-border-radius: 8px;-moz-border-radius: 8px;	border-radius: 8px;
@@ -682,7 +696,7 @@ nav a {
   margin: 0 auto 6px;
   padding: 3px;
   }
-  
+
 .messageBox button:disabled {
   cursor: default !important;
   color: gray !important;
@@ -771,19 +785,19 @@ nav a {
     background-image: -moz-linear-gradient(#B5B5B5, #93969B) !important;
     background-color: #B5B5B5;
  }
- 
+
 .desktop .kmw-key-shift{
     background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, color-stop(0%, #DBDBDB), color-stop(100%, #C0C0C4));
     background-image: -moz-linear-gradient(#DBDBDB, #C0C0C4) !important;
     background-color: #DBDBDB;
 }
- 
+
  .desktop .kmw-key-shift-on {
     background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, color-stop(0%, #B5B5B5), color-stop(100%, #93969B));
     background-image: -moz-linear-gradient(#B5B5B5, #93969B) !important;
     background-color: #93969B;
  }
- 
+
  .desktop  .kmw-key-shift .kmw-key-text, .desktop  .kmw-key-shift-on .kmw-key-text { color: gray; font-size: 0.9em !important; text-shadow: 0 1px 1px #fff;}
  .desktop  .kmw-key-shift .kmw-key-text, .desktop  .kmw-key-shift-on .kmw-key-text { top: 10%; }
  .desktop  .kmw-key-label { top: 5%; }
@@ -819,7 +833,7 @@ nav a {
 }
 
 #free-open-source {
-  color: #606060; 
+  color: #606060;
   font-size: 8pt;
   font-weight: normal;
   display: block;
@@ -847,7 +861,7 @@ nav a {
   font-size: 9px;
   text-align: justify;
 }
-  
+
 #bookmarklet div a {
   padding: 4px 4px 4px 24px;
 	background: #D3DAED url('../img/keymanweb-icon-16.png') 4px 4px no-repeat;
@@ -859,7 +873,7 @@ nav a {
 	display: inline-block;
 	height: 16px;
 	overflow: hidden;
-  white-space: nowrap;	
+  white-space: nowrap;
 }
 
 #learn div {

--- a/cdn/dev/css/kmw-mobile.css
+++ b/cdn/dev/css/kmw-mobile.css
@@ -1,6 +1,6 @@
 /* KMW LIVE CSS for iPhone and other mobiles */
 
-/* 
+/*
 ======================
 ==Universal Elements==
 ======================
@@ -15,7 +15,7 @@ body {
   width:100%;height:100%;
   font-family: Verdana, Arial, Helvetica, sans-serif;
   color:#2D2C2C;
-  background-color: #eeeeee;  
+  background-color: #eeeeee;
   margin:0px;
   }
 
@@ -30,39 +30,53 @@ a:hover {
 
 h3 {
   font-size:18px;
-  }		
-  
+  }
+
 p {
   font-size:13px;
   line-height:1.5em;
   }
-/*  
+/*
 header, #content, footer {
   margin:0px auto;
   clear: both;
   }
-*/ 
+*/
 
 hr {
   display: none;
   }
 
-/*  
+/*
 .box {
   -webkit-border-radius: 8px;-moz-border-radius: 8px;	border-radius: 8px;
   -moz-box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.5); -webkit-box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.5); box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.5);
   }
-*/   
-/* 
+*/
+/*
 ===================
 ==Header Elements==
 ===================
-*/	
-header,#headerBackground,#headerLeft,#headerRight {
+*/
+header img, #headerLeft {
   display: none;
-  }
+}
+header {
+  position: absolute;
+  top: 190px;
+  background: #776666;
+  font-size: 9pt;
+  padding: 6px 0;
+  color: white;
+  width: 100%;
+  text-align: center;
+}
+header a {
+  color: #c0c0ff;
+  text-decoration: underline;
+}
 
-/* 
+/*
 ====================
 ==Content Elements==
 ====================
@@ -70,12 +84,12 @@ header,#headerBackground,#headerLeft,#headerRight {
 #content {
   width: 100%;    /* specific for mobile and tablet */
   margin: 0px auto;
-  background-color: #eeeeee;  
+  background-color: #eeeeee;
   /* min-height:375px; */
   }
 
-  
-/* KMW Main App */	
+
+/* KMW Main App */
 #app {
   width:100%;
   margin: 0px;
@@ -86,14 +100,14 @@ header,#headerBackground,#headerLeft,#headerRight {
 
 #exampleBox,#example {
   display:none;
-  }	
+  }
 
 #messageContainer {
   width: 80%;
   float:left;
   height: 50%;
   }
-  
+
 #message {
   height:144px;
   width: 100%;/*554px;*/
@@ -103,13 +117,13 @@ header,#headerBackground,#headerLeft,#headerRight {
   font-size:17px;
   font-family:SindhiWeb,Verdana,GeezWeb,LaoWeb,TibetanWeb,MyanmarWeb,SinhalaWeb,TamilWeb,KhmerWeb,LatinWeb,OriyaWeb,EgyptianWeb !important;
   }
-  
+
   #font-size{
     display: none;
   }
 
 /* KMW App Buttons */
-          
+
 #buttons {
   float: right;
   width: 40px;
@@ -119,10 +133,10 @@ header,#headerBackground,#headerLeft,#headerRight {
 
 #buttons div {
   /*width:50px;*/
-  -webkit-border-radius: 4px; -moz-border-radius: 4px; border-radius: 4px;	
+  -webkit-border-radius: 4px; -moz-border-radius: 4px; border-radius: 4px;
   background: #eeeeee;
   border: none;
-  margin: 0px 0px 4px 10px;  
+  margin: 0px 0px 4px 10px;
   height:40px;
   width: 41px;
   padding: 0px;
@@ -185,7 +199,7 @@ header,#headerBackground,#headerLeft,#headerRight {
 #buttons div * {
   display:inline;
   }
-  
+
 #buttons p {  /* buttons have no text label on mobiles */
   display:none;
   }
@@ -193,18 +207,18 @@ header,#headerBackground,#headerLeft,#headerRight {
 div.links {
   cursor:pointer;
   }
-  
+
 div.linksOff {
   cursor:default !important;
   border:none;
-  /*border: 1px solid #cccccc !important; */  
+  /*border: 1px solid #cccccc !important; */
   }
-  
+
 div.linksOff * {
   color: gray;
   -webkit-user-select:none;
   }
-  
+
 #tweetcount,#twitter span {
   display: block;
   font: bold 0.6em Helvetica, Verdana, Arial, sans-serif;
@@ -226,7 +240,7 @@ div.linksOff * {
   font-size: 24pt;
   background: #fff;
 }
-  
+
 #mobile-increase{
   height: 40px;
   line-height: 40px;
@@ -237,13 +251,13 @@ div.linksOff * {
   height: 40px;
   line-height: 40px;
 }
-  
-/* Aside Elements */	
+
+/* Aside Elements */
 aside, aside div {
   display:none;
   }
-	    
-/* 
+
+/*
 ===================
 ==Footer Elements==
 ===================
@@ -251,7 +265,7 @@ aside, aside div {
 .footer,footer {
   display:none;
   }
-    
+
 #facebookPost {
   position: fixed;
   width: 640px;
@@ -326,7 +340,7 @@ aside, aside div {
   margin: 0 auto 6px;
   padding: 3px;
   }
-  
+
 .messageBox button:disabled {
   cursor: default !important;
   color: gray !important;
@@ -384,67 +398,67 @@ aside, aside div {
 }
 
 #twitter span {
-  font-weight: normal; 
-  text-align: center;   
-  position:relative; 
-  display:block; 
-  width:30px; 
+  font-weight: normal;
+  text-align: center;
+  position:relative;
+  display:block;
+  width:30px;
   height:10px;
   left: 0px;
-  top:31px; 
+  top:31px;
 }
 
 #twitter span.long {
   color: red;
 }
- 
- /* Additional rules for portrait orientation */  
+
+ /* Additional rules for portrait orientation */
 @media only screen and (orientation: portrait) {
-    
+
   #message {
     height: 170px;
     }
-    
+
   #messageContainer {
     float: left;
     width: 80%;
     height: 40%;
-    }    
-}      
+    }
+}
 
 
- /* Additional rules for landscape orientation */  
+ /* Additional rules for landscape orientation */
 @media only screen and (orientation: landscape) {
 
   #messageContainer {
     float: left;
     width: 85%;
     height: 50%;
-    }    
+    }
   #message {
     height: 50%;
     }
   #buttons {
     margin: 4px 15px 4px 0;
     }
-    
+
     #font{
       display: none;
     }
 }
 
-/* 
+/*
 ======================
 ==Keyboard Styling==
 ======================
 */
 
 #kmw-language-menu p {
-  color: #000 !important; 
+  color: #000 !important;
 }
 
 #kmw-language-menu .selected {
-  background-color: gray !important; 
+  background-color: gray !important;
 }
 
 

--- a/cdn/dev/css/kmw-tablet.css
+++ b/cdn/dev/css/kmw-tablet.css
@@ -1,6 +1,6 @@
-/* KMW LIVE CSS for iPad and other tablet devices */   
+/* KMW LIVE CSS for iPad and other tablet devices */
 
-/* 
+/*
 ======================
 ==Universal Elements==
 ======================
@@ -30,19 +30,19 @@ a:hover {
 
 h3 {
   font-size:18px;
-  }		
-  
+  }
+
 p {
   font-size:13px;
   line-height:1.5em;
   }
-  
+
 header, footer {
   width:100%;
   margin:0px auto;
   /*clear: both;*/
   }
-  
+
 hr {
   display: none;
   }
@@ -51,12 +51,12 @@ hr {
   -webkit-border-radius: 8px;-moz-border-radius: 8px;	border-radius: 8px;
   -moz-box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.5); -webkit-box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.5); box-shadow: 0px 1px 3px 0px rgba(0, 0, 0, 0.5);
   }
-  
-/* 
+
+/*
 ===================
 ==Header Elements==
 ===================
-*/	
+*/
 header {
   margin-top:0px;
   }
@@ -65,16 +65,16 @@ header {
   display: block; /* default (inline) display inserts an unwanted bottom border */
   margin-top:0px;
   height:60px;
-  /*-webkit-border-radius: 0px 0px 8px 8px; -moz-border-radius: 0px 0px 8px 8px; border-radius: 0px 0px 8px 8px;*/	
-  }	
+  /*-webkit-border-radius: 0px 0px 8px 8px; -moz-border-radius: 0px 0px 8px 8px; border-radius: 0px 0px 8px 8px;*/
+  }
 
 header > div > img {
   display: block;
   width: 100%;
   height: 8px;
 }
-  
-/* 
+
+/*
 ====================
 ==Content Elements==
 ====================
@@ -86,8 +86,8 @@ header > div > img {
   /*min-height:375px;*/
   }
 
-  
-/* KMW Main App */	
+
+/* KMW Main App */
 #app {
   /*float:left;*/
   /*height:330px;*/
@@ -101,13 +101,13 @@ header > div > img {
 
 #exampleBox, #example {
   display: none;
-  }	
+  }
 
 #messageContainer {
   width: 80%;
   float:left;
   }
-  
+
 #message {
   height:195px;
   width: 100%;/*554px;*/
@@ -117,8 +117,8 @@ header > div > img {
   font-size:17px;
   font-family:SindhiWeb,Verdana,GeezWeb,LaoWeb,TibetanWeb,MyanmarWeb,SinhalaWeb,TamilWeb,KhmerWeb,LatinWeb,OriyaWeb,EgyptianWeb !important;
   }
-    
-/* KMW App Buttons */	
+
+/* KMW App Buttons */
 
 #buttons {
   float: right;
@@ -129,7 +129,7 @@ header > div > img {
 
 #buttons div {
   width:140px;
-  -webkit-border-radius: 4px; -moz-border-radius: 4px; border-radius: 4px;	
+  -webkit-border-radius: 4px; -moz-border-radius: 4px; border-radius: 4px;
   background: #fff;
   border: 1px solid #888888;
   margin: 0px 10px;
@@ -146,7 +146,7 @@ header > div > img {
   color: gray !important;
   border-color: gray !important;
   }
-  
+
 #buttons p{
   margin-left: 41px;
 }
@@ -194,12 +194,12 @@ header > div > img {
 div.links {
   cursor:pointer;
   }
-  
+
 div.linksOff {
   cursor:default !important;
-  border: 1px solid #cccccc !important;  
+  border: 1px solid #cccccc !important;
   }
-  
+
 div.linksOff * {
   color: gray;
   -webkit-user-select:none;
@@ -238,7 +238,7 @@ aside {
   position: fixed;
   /* -webkit-border-radius: 8px 8px 0px 0px;	-moz-border-radius: 8px 8px 0px 0px; border-radius: 8px 8px 0px 0px; */
   }
-  
+
 nav ul {
   list-style: none outside none;
   width:90%;
@@ -256,8 +256,8 @@ nav a {
   font-family:Tahoma;
   font-weight:bold;
   font-size:10.7px;
-  }	
-  
+  }
+
 #facebookPost {
   position: fixed;
   width: 640px;
@@ -335,7 +335,7 @@ nav a {
   margin: 0 auto 6px;
   padding: 3px;
   }
-  
+
 .messageBox button:disabled {
   cursor: default !important;
   color: gray !important;
@@ -408,18 +408,33 @@ nav a {
 #headerBackground {
   width: 100%;
   background-color:white;
-  }
+}
+
 #headerLeft {
   float: left;
   margin-left: 28px;
-  }
+}
+
 #headerRight {
-  display: none;
+  text-align: right;
   height: 40px;
   float: right;
   padding-bottom: 33px;
   padding-right: 10px;
-  }
+}
+
+#headerRight-beta {
+  display: block;
+  font-weight: bold;
+  color: red;
+  font-size: 16pt;
+  padding: 16px 12px 0;
+}
+
+#headerRight-link {
+  padding: 0 12px 0;
+}
+
 
 #instructions {
   margin:10px;
@@ -427,7 +442,7 @@ nav a {
   color: white;
 }
 
-/* Additional rules for portrait orientation */  
+/* Additional rules for portrait orientation */
 @media only screen and (orientation: landscape) {
   #buttons{
     padding-top: 11px;
@@ -456,34 +471,34 @@ nav a {
     font-size: 24pt;
     background: #fff;
   }
-    
+
   #mobile-increase{
     height: 40px;
     line-height: 40px;
     border-bottom: solid 1px #000;
   }
-  
+
   #mobile-decrease{
     height: 40px;
     line-height: 40px;
   }
 }
-  
-/* Additional rules for portrait orientation */  
+
+/* Additional rules for portrait orientation */
 @media only screen and (orientation: portrait) {
-  
+
   #app {
     width: 97%;
     }
-    
+
   #message {
     height: 350px;
     }
-    
+
   #messageContainer {
     width: 100%;
     }
-      
+
   #buttons {
     clear:both;
     width: 90%;
@@ -494,24 +509,24 @@ nav a {
     margin: 10px 10px 0;
     width: 130px;
     height: 40px;
-    }      
+    }
   #twitter { margin-left: 10px; margin-right: 10px;}
-  
+
   #font{
     position: relative;
     top: 4px;
   }
-  
+
   #font span:first-child{
     margin-left: 3px;
   }
-  
+
   #font p{
     margin-left: 8px;
     position: relative;
     top: -4px;
   }
-  
+
   #mobile-font{
     display: none;
     width: 301px;
@@ -522,7 +537,7 @@ nav a {
     text-align: center;
     font-size: 24pt;
   }
-    
+
   #mobile-increase{
     float: right;
     width: 136px;
@@ -532,7 +547,7 @@ nav a {
     border: 1px solid #888888;
     border-radius: 4px;
   }
-  
+
   #mobile-decrease{
     float: right;
     width: 136px;
@@ -545,18 +560,18 @@ nav a {
   }
 }
 
-/* 
+/*
 ======================
 ==Keyboard Styling==
 ======================
 */
 
 #kmw-language-menu p {
-  color: #000 !important; 
+  color: #000 !important;
 }
 
 #kmw-language-menu .selected {
-  background-color: gray !important; 
+  background-color: gray !important;
 }
 
 .tablet .kmw-keyboard-dari_clra .kmw-key-default .kmw-key-text {

--- a/inc/head.php
+++ b/inc/head.php
@@ -2,9 +2,9 @@
   session_start();
   require_once('servervars.php');
 
-  $hasBeta = false;
   $kmw_tiers = array('alpha', 'beta', 'stable');
   $kmw_builds = get_keymanweb_versions();
+  $hasBeta = version_compare($kmw_builds['stable'], $kmw_builds['beta']) < 0;
 
   if(isset($_REQUEST['version']) && preg_match('/^(\d+)\.(\d+)\.(\d+)$/', $_REQUEST['version'])) {
     $kmwbuild = $_REQUEST['version'];
@@ -21,18 +21,10 @@
       // Note:  if API calls fail to retrieve proper version data,
       //        the return will be 0 due to equal fallback versions.
       //        Net result: selection of the 'stable' tier.
-      if(version_compare($kmw_builds['stable'], $kmw_builds['beta']) < 0) {
-        $tier = 'beta';
-      } else {
-        $tier = 'stable';
-      }
+      $tier = $hasBeta ? 'beta' :'stable';
     }
 
     $kmwbuild = $kmw_builds[$tier];
-  }
-
-  if(version_compare($kmw_builds['stable'], $kmw_builds['beta']) < 0) {
-    $hasBeta = true;
   }
 
   $version = get_major_version($kmwbuild);

--- a/inc/head.php
+++ b/inc/head.php
@@ -2,15 +2,16 @@
   session_start();
   require_once('servervars.php');
 
+  $hasBeta = false;
   $kmw_tiers = array('alpha', 'beta', 'stable');
+  $kmw_builds = get_keymanweb_versions();
 
   if(isset($_REQUEST['version']) && preg_match('/^(\d+)\.(\d+)\.(\d+)$/', $_REQUEST['version'])) {
     $kmwbuild = $_REQUEST['version'];
-    $tier = 'stable';
+    $tier = 'stable'; // this may be inaccurate
   } else {
     // Used to enable the release-tier selection code below.
     // For general usage, we recommend `get_keymanweb_version($tier)` instead.
-    $kmw_builds = get_keymanweb_versions();
 
     if(isset($_REQUEST['tier']) && in_array($_REQUEST['tier'], $kmw_tiers, TRUE)) {
       $tier = $_REQUEST['tier'];
@@ -29,6 +30,11 @@
 
     $kmwbuild = $kmw_builds[$tier];
   }
+
+  if(version_compare($kmw_builds['stable'], $kmw_builds['beta']) < 0) {
+    $hasBeta = true;
+  }
+
   $version = get_major_version($kmwbuild);
 ?>
 <!DOCTYPE html>
@@ -203,7 +209,9 @@
     attachType:'auto',
     setActiveOnRegister:'false'
   }).then(function() {
-    addKeyboards();
+    if(typeof addKeyboards == 'function') {
+      addKeyboards();
+    }
     if(localKeyboard && localLanguage)
       keyman.setActiveKeyboard(localKeyboard, localLanguage);
     document.getElementById('message').focus();

--- a/inc/servervars.php
+++ b/inc/servervars.php
@@ -83,7 +83,7 @@
   // Uses official API for version checking, but is not optimized for
   // version-checking against multiple release tiers.
   function get_keymanweb_version($tier) {
-    $json = @file_get_contents(KeymanHosts::Instance()->r_keymanweb_com . "/code/get-version/web/$tier");
+    $json = @file_get_contents(KeymanHosts::Instance()->api_keyman_com . "/version/web/$tier");
     if($json) {
       $json = json_decode($json);
     }

--- a/index.php
+++ b/index.php
@@ -22,9 +22,16 @@ require_once('inc/head.php');
 
 <header>
   <div id='headerBackground'>
+    <div id='headerRight'>
+      <?php if($tier != 'stable') { ?>
+      <span id='headerRight-beta'>Pre-release version</span> <a id='headerRight-link' href='?tier=stable'>Return to version <?= $kmw_builds['stable'] ?></a>
+      <?php } else if($hasBeta) { ?>
+        <span id='headerRight-beta'>New release!</span> <a id='headerRight-link' href='?tier=beta'>Try beta version <?= $kmw_builds['beta'] ?></a>
+      <?php } ?>
+    <!--<a href='https://keyman.com/keymanweb/' target='blank'><img src="<?php echo cdn("img/info.png"); ?>" /></a>-->
+    </div>
     <div id='headerLeft'><img src="<?php echo cdn("img/keymanweb-logo-88.png"); ?>" alt='KeymanWeb.com' /></div>
     <img src="<?php echo cdn("img/headerbar.png"); ?>" alt="" />
-    <div id='headerRight'><a href='https://keyman.com/keymanweb/' target='blank'><img src="<?php echo cdn("img/info.png"); ?>" /></a></div>
   </div>
 </header>
 


### PR DESCRIPTION
Fixes #21.

The banner shows only when we are in a beta phase.

# Tablet view

![image](https://user-images.githubusercontent.com/4498365/110066366-60bd9a80-7dc5-11eb-94ef-3521cbfe4c0f.png)

# Phone view

![image](https://user-images.githubusercontent.com/4498365/110066386-6c10c600-7dc5-11eb-8a3c-3527b757a1c8.png)

# Desktop view

![image](https://user-images.githubusercontent.com/4498365/110066421-82b71d00-7dc5-11eb-926a-67788426e853.png)

and for good measure, what users see if they return to the stable version:

![image](https://user-images.githubusercontent.com/4498365/110066497-aed29e00-7dc5-11eb-8985-7b6575eebff7.png)

I think you can figure out what that'll look like on the other form factors 😆 