### PR TITLE
fix: removes use of undefined handler

### DIFF
--- a/prog/languageexample.php
+++ b/prog/languageexample.php
@@ -39,7 +39,7 @@
     if(empty($keyboard)) return '';
     $site = KeymanHosts::Instance()->help_keyman_com;
     $morehelp =
-      "<a target='KeymanWebHelp' onclick='javascript:return openALink(this)' " .
+      "<a target='KeymanWebHelp' " .
       "title='Keyboard help'" .
       "href='$site/go?" .
       (empty($language) ? "" : "language=$language&amp;") .


### PR DESCRIPTION
Fixes #30.

To be safe, I went back to the initial-seed commit; even there, `openALink` was not defined within the repo.  Pretty sure it's been dead this whole time.