### PR TITLE
chore: https for dev hosts

### DIFF
--- a/_common/KeymanHosts.php
+++ b/_common/KeymanHosts.php
@@ -87,7 +87,7 @@
         break;
       case KeymanHosts::TIER_DEVELOPMENT:
         $site_suffix = '.local';
-        $site_protocol = 'http://';
+        $site_protocol = 'https://';
         break;
       }
 


### PR DESCRIPTION
Groundwork required for Chrome 90+ and SameSite cookies, ref keymanapp/keyman#5193.