### PR TITLE
fix: bad use of timerid in cached keyboard lookup

### DIFF
--- a/prog/keyboards.php
+++ b/prog/keyboards.php
@@ -52,7 +52,7 @@
   }
 
   function get_cache_url($version) {
-    return KeymanHosts::Instance()->api_keyman_com ."/cloud/4.0/keyboards?jsonp=keyman.register&languageidtype=bcp47&version=$version&timerid=1"    ;
+    return KeymanHosts::Instance()->api_keyman_com ."/cloud/4.0/keyboards?jsonp=keyman.register&languageidtype=bcp47&version=$version";
   }
 
   function get_cache_file($version) {


### PR DESCRIPTION
Fixes keymanapp/keyman#5904.

The cached lookup of KeymanWeb keyboards should not include a timerid, because KeymanWeb has not setup a corresponding promise to resolve with.

I am also about to push a fix to KeymanWeb to avoid issues if the timerid is present but not valid.