### PR TITLE
fix: let to var

### DIFF
--- a/cdn/dev/js/kmwlive.js
+++ b/cdn/dev/js/kmwlive.js
@@ -247,7 +247,7 @@ $(window).on("load", function() {
   setTimeout(afterInit, 1000);
 });
 
-let afterInitRun = false;
+var afterInitRun = false;
 function afterInit() {
   if(afterInitRun) {
     return;


### PR DESCRIPTION
We still have regular downlevel browser visits to keymanweb.com. This fixes one sentry report:

https://sentry.io/organizations/keyman/issues/3122414112/?project=5983523

Fixes KEYMANWEB-COM-7P.