### PR TITLE
fix: don't attempt to set OSK size before layout is complete

### DIFF
--- a/cdn/dev/js/kmwlive.js
+++ b/cdn/dev/js/kmwlive.js
@@ -122,7 +122,7 @@ $(document).ready(function() {
 
     // We can't proceed any further if KMW hasn't loaded yet.
     // No point handling resizes until that's occurred.
-    if(!getKeymanWeb()) {
+    if(!getKeymanWeb() || !getKeymanWeb().osk) {
       return;
     }
 


### PR DESCRIPTION
Fixes #57.
Fixes KEYMANWEB-COM-2W

Assumption I am making is that `keyman.osk` is not yet init, even if the script is loaded.