### PR TITLE
chore: Move build.sh configure step to start 🦭

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea/**
 cdn/deploy
 
-vendor*
+/vendor
 .data/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea/**
 cdn/deploy
 
-/vendor/
+vendor*
 .data/

--- a/build.sh
+++ b/build.sh
@@ -44,18 +44,7 @@ builder_parse "$@"
 cd "$REPO_ROOT"
 
 if builder_start_action configure; then
-  # Skip if link already exists
-  if [ -L vendor ]; then
-    echo "Skipping because vendor already exists"
-  else
-    # Create link to vendor/ folder
-    KEYMANWEB_CONTAINER=$(_get_docker_container_id)
-    if [ ! -z "$KEYMANWEB_CONTAINER" ]; then
-      docker exec -i $KEYMANWEB_CONTAINER sh -c "ln -s /var/www/vendor vendor && chown -R www-data:www-data vendor"
-    else
-      echo "No Docker container to configure"
-    fi
-  fi
+  # Nothing to do
   builder_finish_action success configure
 fi
 
@@ -106,6 +95,20 @@ if builder_start_action start; then
     echo "${COLOR_RED}ERROR: Docker container doesn't exist. Run ./build.sh build first${COLOR_RESET}"
     builder_finish_action fail start
   fi
+
+  # Skip if link already exists
+  if [ -L vendor ]; then
+    echo "Link to vendor/ already exists"
+  else
+    # Create link to vendor/ folder
+    KEYMANWEB_CONTAINER=$(_get_docker_container_id)
+    if [ ! -z "$KEYMANWEB_CONTAINER" ]; then
+      docker exec -i $KEYMANWEB_CONTAINER sh -c "ln -s /var/www/vendor vendor && chown -R www-data:www-data vendor"
+    else
+      echo "No Docker container running to create link to vendor/"
+    fi
+  fi
+
 
   builder_finish_action success start
 fi


### PR DESCRIPTION
Incorporates similar change from keymanapp/help.keyman.com#685 of moving the `./build.sh configure` step to the end of `start`.
