### PR TITLE
refactor: Update servervars to use KeymanHosts 🦭

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,7 @@ builder_parse "$@"
 
 function test_docker_container() {
   # Note: ci.yml replicates these
+  echo "TIER_TEST" > tier.txt
 
   # Run unit tests
   docker exec $KEYMANWEB_CONTAINER_DESC sh -c "vendor/bin/phpunit --testdox"
@@ -40,6 +41,16 @@ function test_docker_container() {
   # Check all internal links
   # NOTE: link checker runs on host rather than in docker image
   npx broken-link-checker http://localhost:${PORT_KEYMANWEB_COM} --ordered --recursive --host-requests 10 -e --filter-level 3
+
+  # Check for errors
+  if docker container logs $KEYMANWEB_CONTAINER_DESC 2>&1 | grep -q 'php7'; then
+    echo 'PHP reported errors or warnings:'
+    docker container logs $KEYMANWEB_CONTAINER_DESC 2>&1 | grep 'php7'
+    exit 1
+  else
+    echo 'No PHP errors found'
+    exit 0
+  fi
 }
 
 builder_run_action configure  bootstrap_configure

--- a/cdn/dev/js/kmwlive.js
+++ b/cdn/dev/js/kmwlive.js
@@ -524,7 +524,7 @@ function updateExample(kbdname) {
 	  }
 	}
 	keymanExample.innerHTML = 'Loading...';
-	var link = '//'+demoDomain+'/prog/languageexample.php?keyboard='+kbdname+'&language='+activeLanguage;
+	var link = demoDomain+'/prog/languageexample.php?keyboard='+kbdname+'&language='+activeLanguage;
 	xmlhttp.open('GET', link, true);
 	xmlhttp.send(null);
 

--- a/cdn/dev/keys/keyrenderer.js
+++ b/cdn/dev/keys/keyrenderer.js
@@ -3,7 +3,7 @@ if(typeof KeyRenderer == 'undefined')
   var KeyRenderer = new function()
   {
     if(location.hostname.indexOf('keymanweb.com.localhost')>=0)
-      var site='https://s.keyman.com';
+      var site='http://s.keyman.com.localhost';
     else
       var site='https://s.keyman.com';
   

--- a/cdn/dev/keys/keyrenderer.js
+++ b/cdn/dev/keys/keyrenderer.js
@@ -2,8 +2,8 @@ if(typeof KeyRenderer == 'undefined')
 {
   var KeyRenderer = new function()
   {
-    if(location.hostname.indexOf('keymanweb.com.local')>=0)
-      var site='s.keyman.com.local';
+    if(location.hostname.indexOf('keymanweb.com.localhost')>=0)
+      var site='s.keyman.com.localhost';
     else
       var site='s.keyman.com';
   

--- a/cdn/dev/keys/keyrenderer.js
+++ b/cdn/dev/keys/keyrenderer.js
@@ -3,9 +3,9 @@ if(typeof KeyRenderer == 'undefined')
   var KeyRenderer = new function()
   {
     if(location.hostname.indexOf('keymanweb.com.localhost')>=0)
-      var site='s.keyman.com.localhost';
+      var site='https://s.keyman.com';
     else
-      var site='s.keyman.com';
+      var site='https://s.keyman.com';
   
     this.render = function(s)
     {
@@ -53,14 +53,14 @@ if(typeof KeyRenderer == 'undefined')
               kn = spkey[ks];
               if(kn) 
               { 
-                u = "<img src='http://"+site+"/keys/tr.gif' title='"+ks+"' alt='"+ks+"' class='key-"+kn+"' />";
+                u = "<img src='"+site+"/keys/tr.gif' title='"+ks+"' alt='"+ks+"' class='key-"+kn+"' />";
                 t = t.substr(0,x); ch = '*';
               }
             }
             
-            if(t.indexOf('C') >= 0) r += "<img src='http://"+site+"/keys/tr.gif' title='Ctrl' alt='Ctrl' class='key-ctrl' />";
-            if(t.indexOf('S') >= 0) r += "<img src='http://"+site+"/keys/tr.gif' title='Shift' alt='Shift' class='key-shift' />";
-            if(t.indexOf('A') >= 0) r += "<img src='http://"+site+"/keys/tr.gif' title='Alt' alt='Alt' class='key-alt' />";
+            if(t.indexOf('C') >= 0) r += "<img src='"+site+"/keys/tr.gif' title='Ctrl' alt='Ctrl' class='key-ctrl' />";
+            if(t.indexOf('S') >= 0) r += "<img src='"+site+"/keys/tr.gif' title='Shift' alt='Shift' class='key-shift' />";
+            if(t.indexOf('A') >= 0) r += "<img src='"+site+"/keys/tr.gif' title='Alt' alt='Alt' class='key-alt' />";
             
             r += u;
             endspan = true;
@@ -86,7 +86,7 @@ if(typeof KeyRenderer == 'undefined')
             else if(ch == '&quot;') ch = '"';
           }
           chv = ch.charCodeAt(0);
-          r += "<img src='http://"+site+"/keys/tr.gif' class='key-"+chv.toString()+"' title='"+this.encodeEntities(ch)+"' alt='"+this.encodeEntities(ch)+"' />";
+          r += "<img src='"+site+"/keys/tr.gif' class='key-"+chv.toString()+"' title='"+this.encodeEntities(ch)+"' alt='"+this.encodeEntities(ch)+"' />";
         }
         if(endspan) r += "</span>";
         i++;

--- a/inc/head.php
+++ b/inc/head.php
@@ -85,7 +85,7 @@
     beforeSend: prepareEvent,
     dsn: "https://11f513ea178d438e8f12836de7baa87d@o1005580.ingest.sentry.io/5983523",
     release: sentryRelease,
-    environment: location.host.match(/\.local$/) ? 'development' : location.host.match(/(^|\.)keyman-staging\.com$/) ? 'staging' : 'production',
+    environment: location.host.match(/\.localhost$/) ? 'development' : location.host.match(/(^|\.)keyman-staging\.com$/) ? 'staging' : 'production',
   });
 </script>
 
@@ -213,7 +213,7 @@
     }
     if(typeof addKeyboards == 'function') {
       addKeyboards();
-    } <?php if ($site_suffix == ".local") {
+    } <?php if ($site_suffix == ".localhost") {
       echo 'else {
       console.warn("-- Fallback:  not using the server\'s cached keyboard set! --");
       // Server caching may not be active in local dev instances of the server.

--- a/inc/servervars.php
+++ b/inc/servervars.php
@@ -32,10 +32,11 @@
     require_once __DIR__ . '/../cdn/deploy/cdn.php';
   }
 
-  $TestServer = (KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_DEVELOPMENT) || 
-    (KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_TEST) ? true : false;
+  $site_suffix = KeymanHosts::Instance()->Site_Suffix();
 
   // $site_protocol is used only by util.php at this time.
+  $TestServer = (KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_DEVELOPMENT) || 
+    (KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_TEST) ? true : false;
   $site_protocol = $TestServer ? 'http://' : 'https://';
     
   $url_keymanweb_res = KeymanHosts::Instance()->r_keymanweb_com;

--- a/inc/servervars.php
+++ b/inc/servervars.php
@@ -32,42 +32,20 @@
     require_once __DIR__ . '/../cdn/deploy/cdn.php';
   }
 
-  $site_url = 'keymanweb.com';
-
-  // We allow the site to strip off everything post its basic siteurl
-
-  function GetHostSuffix() {
-    global $site_url;
-    if(!isset($_SERVER['SERVER_NAME'])) return '';
-
-    $name = $_SERVER['SERVER_NAME'];
-
-    if(stripos($name, $site_url.'.') == 0) {
-      return substr($name, strlen($site_url), 1024);
-    }
-    return '';
-  }
-
-  $site_suffix = GetHostSuffix();
+  $TestServer = (KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_DEVELOPMENT) || 
+    (KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_TEST) ? true : false;
 
   // $site_protocol is used only by util.php at this time.
-  $site_protocol = (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443) ? 'https://' : 'http://';
+  $site_protocol = $testServer ? 'http://' : 'https://';
+    
+  $url_keymanweb_res = KeymanHosts::Instance()->r_keymanweb_com;
+  $staticDomainRoot= KeymanHosts::Instance()->s_keyman_com;  
 
-  if($site_suffix == '') {
-    $TestServer = false;
-    $url_keymanweb_res = "https://r.keymanweb.com";
-    $staticDomainRoot="https://s.keyman.com/";
-  } else {
-    $TestServer = true;
-    $url_keymanweb_res = "https://r.keymanweb.com"; /// local dev domain is usually not available
-    $staticDomainRoot="https://s.keyman.com/";
-  }
+  $site_keymanwebhelp = KeymanHosts::Instance()->help_keyman_com;
+  $site_keymanwebdemo = KeymanHosts::Instance()->keymanweb_com;
+  $site_keyman        = KeymanHosts::Instance()->keyman_com;
 
-  $site_keymanwebhelp = "help.keyman.com{$site_suffix}";
-  $site_keymanwebdemo = "keymanweb.com{$site_suffix}";
-  $site_keyman        = "keyman.com";
-
-  $staticDomain="s.keyman.com/kmw/engine";
+  $staticDomain= $staticDomainRoot . "/kmw/engine";
 
   function cdn($file) {
     global $cdn, $staticDomain, $TestServer;

--- a/inc/servervars.php
+++ b/inc/servervars.php
@@ -25,6 +25,9 @@
   const SENTRY_DSN = 'https://11f513ea178d438e8f12836de7baa87d@o1005580.ingest.sentry.io/5983523';
   \Keyman\Site\Common\KeymanSentry::init(SENTRY_DSN);
 
+  // latest known version of KeymanWeb
+  const FALLBACK_KMW_VERSION = '16.0.143';
+
   if(file_exists(__DIR__ . '/../cdn/deploy/cdn.php')) {
     require_once __DIR__ . '/../cdn/deploy/cdn.php';
   }
@@ -92,7 +95,7 @@
       $version = $json->version;
     } else {
       // If the get-version API fails, we'll use the latest known version
-      $version = "15.0.272";
+      $version = FALLBACK_KMW_VERSION;
     }
     return $version;
   }
@@ -103,7 +106,7 @@
       $json = json_decode($json);
     }
 
-    $fallback_version = "15.0.274";
+    $fallback_version = FALLBACK_KMW_VERSION;
 
     foreach(array('alpha', 'beta', 'stable') as $tier) {
       if(!$json || !property_exists($json, $tier)) {

--- a/inc/servervars.php
+++ b/inc/servervars.php
@@ -36,7 +36,7 @@
     (KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_TEST) ? true : false;
 
   // $site_protocol is used only by util.php at this time.
-  $site_protocol = $testServer ? 'http://' : 'https://';
+  $site_protocol = $TestServer ? 'http://' : 'https://';
     
   $url_keymanweb_res = KeymanHosts::Instance()->r_keymanweb_com;
   $staticDomainRoot= KeymanHosts::Instance()->s_keyman_com;  


### PR DESCRIPTION
Relates to keymanapp/keyman.com#403

Since the Keyman websites are using a consistent set of KeymanHosts, this refactors servervars to use KeymanHosts.

* Also removes the need for string manipulations with the site protocol
* Includes a :cherries: pick of #93 to staging
* Fix the builder test action (checks PHP errors)

TODO:
- [x] Troubleshoot development tier needing to use https://s.keyman.com instead of http://docker.host.internal:8054 in KeymanHosts.php ($this->s_keyman_com) for: - might be resolved with keymanapp/shared-sites#10
  * local api.keyman.com
  * local keymanweb.com