### PR TITLE
fix: use relative URL for language example lookup

### DIFF
--- a/cdn/dev/js/kmwlive.js
+++ b/cdn/dev/js/kmwlive.js
@@ -487,7 +487,7 @@ function updateLink(kbdname)
 
 var langExamples = [];
 
-function updateExample(kbdname) {
+async function updateExample(kbdname) {
   var keymanExample=document.getElementById("example"),
   exampleBox=document.getElementById("exampleBox");
   if (!keymanExample || !exampleBox) return false;
@@ -510,24 +510,19 @@ function updateExample(kbdname) {
   }
 
   langExamples[activeLanguage + '_' + kbdname] = 'Loading...';
-
-	var xmlhttp;
-	if(window.XMLHttpRequest) xmlhttp = new XMLHttpRequest();
-	else if(window.ActiveXObject) xmlhttp = new ActiveXObject('Microsoft.XMLHTTP');
-	else return false;
-
-  xmlhttp.onreadystatechange = function()
-	{
-	  if(xmlhttp.readyState == 4)
-	  {
-      langExamples[activeLanguage + '_' + kbdname] = keymanExample.innerHTML = xmlhttp.responseText;
-	  }
-	}
 	keymanExample.innerHTML = 'Loading...';
-	var link = demoDomain+'/prog/languageexample.php?keyboard='+kbdname+'&language='+activeLanguage;
-	xmlhttp.open('GET', link, true);
-	xmlhttp.send(null);
 
-	//keymanExample.style.display = 'block';
-	//keymanExample.innerHTML = "Example: To enter <span class='highlightExample'>?????</span>, type <span class='highlightExample'>thamiz</span> on your keyboard";
+	const link = '/prog/languageexample.php?keyboard='+kbdname+'&language='+activeLanguage;
+  try {
+    const response = await fetch(link);
+    if(response.status == 200) {
+      const content = await response.text();
+      langExamples[activeLanguage + '_' + kbdname] = keymanExample.innerHTML = content;
+    } else {
+      throw new Error(`Unable to retrieve content, status was ${response.status}: ${response.statusText}`);
+    }
+  } catch(e) {
+    langExamples[activeLanguage + '_' + kbdname] = keymanExample.innerHTML = 'Error retrieving example: '+e.message;
+    throw e;
+  }
 }

--- a/inc/head.php
+++ b/inc/head.php
@@ -85,7 +85,11 @@
     beforeSend: prepareEvent,
     dsn: "https://11f513ea178d438e8f12836de7baa87d@o1005580.ingest.sentry.io/5983523",
     release: sentryRelease,
-    environment: location.host.match(/\.localhost$/) ? 'development' : location.host.match(/(^|\.)keyman-staging\.com$/) ? 'staging' : 'production',
+    environment:
+      // TODO: https://github.com/keymanapp/shared-sites/issues/13
+      ['www.keymanweb.com','keymanweb.com', 'web.keyman.com'].includes(location.host) ? 'production' :
+      ['web.keyman-staging.com'].includes(location.host) ? 'staging' :
+      'development',
   });
 </script>
 


### PR DESCRIPTION
Fixes #101.

Also fixes the sentry reporting (which will need to be revisited later once we cleanup KeymanHosts).