### PR TITLE
fix: link subscribe button to mailchimp form

### DIFF
--- a/cdn/dev/js/kmwlive.js
+++ b/cdn/dev/js/kmwlive.js
@@ -235,6 +235,11 @@ $(document).ready(function() {
     },2000);
   });
 
+  // Email subscribe form
+  $('.subscribe').click(function(){
+    $('#mc-embedded-subscribe-form').submit();
+  });
+
   //Cannot detect change of content from KMW, so use a timer instead to refresh button state
   //$('#message').bind("keypress keyup keydown change click focus blur", refreshButtons);
   window.setInterval(refreshButtons,200);


### PR DESCRIPTION
Fixes #78.

Once upon a refactor, lost in the deep dark mists of time, a line of code was missed. This change restores that line to its position of glory.