### PR TITLE
feat: support v17 language examples and tweak layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       KEYMANHOSTS_TIER: TIER_TEST
+      # Composer started complaining about running as root, but we don't care in a GHA
+      COMPOSER_ALLOW_SUPERUSER: 1
 
     steps:
     - name: Checkout

--- a/cdn/dev/css/kmw-desktop.css
+++ b/cdn/dev/css/kmw-desktop.css
@@ -126,10 +126,6 @@ header > div > img {
     border-top-left-radius: 10px;
   }
 
-  #exampleBox{
-    min-height: 25px;
-  }
-
 #example,#help {
   margin:8px 10px;
   background-color:#95C6D6;
@@ -142,14 +138,14 @@ header > div > img {
   visibility: hidden;
   width:685px;
   min-height: 45px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   padding-top: 5px;
 }
 
 #example a{
-  float: right;
-  margin-right: 10px;
-  position: relative;
-  top: -10px;
+  padding-left: 10px;
 }
 
 textarea {

--- a/cdn/dev/keys/keys.css
+++ b/cdn/dev/keys/keys.css
@@ -1,7 +1,30 @@
 /* example and key images */
 
+.highlightKeys kbd {
+  border: solid 1px #808080;
+  border-radius: 4px;
+  background: #cccccf;
+  color: black;
+  font-family: Verdana; /* web safe font which is clearer for small key caps */
+  font-weight: normal;
+  min-width: 16px;
+  display: inline-block;
+  box-shadow: 2px 2px 1px rgba(128, 128, 128, 0.3);
+  margin-right: 4px;
+}
+
+.highlightKeys kbd.space {
+  min-width: 64px;
+}
+
+.highlightKeys kbd.modifier {
+  margin-right: 0;
+  background: #cccccf;
+  min-width: 28px;
+}
+
 .highlightExample {color: blue; font-weight: bold; }
-.highlightKeys {color: blue; font-weight: bold;}
+.highlightKeys {color: black;}
 
 .highlightKeys .key-print { display: none }
 .highlightKeys img { margin: 0 2px 0 0; background-image: url('../demo/images/keys2.gif'); height: 15px; width: 15px; }

--- a/prog/languageexample.php
+++ b/prog/languageexample.php
@@ -50,7 +50,7 @@
   if($data !== FALSE) {
     echo $data;
   } else {
-    echo "<br/>No example is available, please refer to keyboard help";
+    echo "No example is available, please refer to keyboard help";
   }
 
   echo renderHelpIcon($keyboard, $language);

--- a/prog/renderLanguageExample.php
+++ b/prog/renderLanguageExample.php
@@ -24,17 +24,30 @@
     $keyboard = str_replace('Keyboard_','',$keyboard);
     $string = KeymanHosts::Instance()->api_keyman_com . "/keyboard/" . rawurlencode($keyboard);
     $json = @file_get_contents($string);
-    if($json === FALSE)
+    if($json === FALSE) {
       return FALSE;
+    }
 
     $obj = @json_decode($json, true);
-    if($obj === NULL)
+    if($obj === NULL) {
       return FALSE;
+    }
 
-    if(!isset($obj['languages'][$language]['example']))
-      return FALSE;
+    if(!isset($obj['languages'][$language])) {
+      return false;
+    }
 
-    return "Example: " . DisplayExample($obj['languages'][$language]['example'], false, $language);
+    $lang = $obj['languages'][$language];
+
+    if(isset($lang['examples'])) {
+      $result = DisplayExamples($lang['examples'], $language);
+    } else if(isset($lang['example'])) {
+      $result = DisplayExample($lang['example'], false, $language);
+    } else {
+      $result = FALSE;
+    }
+
+    return $result ? ("Example: " . $result) : FALSE;
   }
 
   function DisplayExample($x, $table = false, $language = '')
@@ -46,15 +59,15 @@
     {
       $keys = KeyRenderer::renderInternal($x['keys'], $table);
       $out = $x['text'];
-      if(isset($x['note'])) $note = " ({$x['note']})"; else $note = '';
+      if(isset($x['note'])) $note = "&nbsp;({$x['note']})"; else $note = '';
 
       if($table)
         $result .= "<td class='highlightExample keymanweb-font' lang='$language'>$out</td><td>{$x['note']}</td><td class='highlightKeys'>$keys</td>";
       else
       $result .=
-        "To enter ".
+        "To enter&nbsp;".
         "<span class='highlightExample keymanweb-font' lang='$language'>$out</span>$note, ".
-        "<br/>type ".
+        "type &nbsp;".
         "<span class='highlightKeys'>$keys</span>$morehelp";
        //" to get ";
       //if(isset($x['note'])) echo " ({$x['note']})";
@@ -191,4 +204,93 @@
   }
 
   $keyRenderer = new KeyRenderer(); // Can also be used statically
-?>
+
+  //------------------------------------------------------------------------------------------
+
+  /**
+   * Render language example from kps 17.0 format examples
+   *
+   * Key format (from kmp-json-file.ts):
+   *
+   * A space-separated list of keys.
+   * - modifiers indicated with "+"
+   * - spacebar is "space"
+   * - plus key is "shift+=" or "plus" on US English (all other punctuation as per key cap).
+   * - Hardware modifiers are: "shift", "ctrl", "alt", "left-ctrl",
+   *   "right-ctrl", "left-alt", "right-alt"
+   * - Key caps should generally be their character for desktop (Latin script
+   *   case insensitive), or the actual key cap for touch
+   * - Caps Lock should be indicated with "caps-on", "caps-off"
+   *
+   * e.g. "shift+a b right-alt+c space plus z z z" represents something like: "Ab{AltGr+C} +zzz"
+   */
+  function RenderExamplesKeys($keys) {
+    $modifiers = [
+      'left-alt' => 'Left Alt',
+      'right-alt' => 'Right Alt',
+      'left-ctrl' => 'Left Ctrl',
+      'left-control' => 'Left Ctrl',
+      'right-ctrl' => 'Right Ctrl',
+      'right-control' => 'Right Ctrl',
+      'shift' => 'Shift',
+      'ctrl' => 'Ctrl',
+      'control' => 'Ctrl',
+      'alt' => 'Alt',
+      'caps-on' => 'Caps (on)',
+      'caps-off' => 'Caps (off)',
+    ];
+
+    // space separated
+    $keys = explode(' ', $keys);
+    foreach($keys as $chord) {
+      if(empty($chord)) {
+        continue;
+      }
+      $chord = explode('+', $chord);
+      $chord_keys = [];
+      foreach($chord as $key) {
+        $class='';
+        $bkey = strtolower($key);
+        if($bkey == 'space') {
+          $key = '&nbsp;'; $class=' class="space"';
+        } else if($bkey == 'plus') {
+          $key = '+';
+        } else if(array_key_exists($bkey, $modifiers)) {
+          $key = $modifiers[$bkey];
+          $class=' class="modifier"';
+        } else {
+          $key = htmlspecialchars($key);
+        }
+        array_push($chord_keys, "<kbd$class>$key</kbd>");
+      }
+      $result .= implode('+', $chord_keys) . " ";
+    }
+    return trim($result);
+  }
+
+  function DisplayExamples($examples, $language = '')
+  {
+    global $morehelp;
+    $result = '';
+
+    if(!is_array($examples) || count($examples) == 0) {
+      return FALSE;
+    }
+
+    $example = $examples[0];
+    if(empty($example['keys'])) {
+      return FALSE;
+    }
+
+    $keys = RenderExamplesKeys($example['keys']);
+    $out = htmlspecialchars($example['text']);
+    $note = isset($example['note']) ? "&nbsp;(" . htmlspecialchars($example['note']) . ")" : "";
+
+    $result .=
+      "To enter&nbsp;".
+      "<span class='highlightExample keymanweb-font' lang='$language'>$out</span>$note, ".
+      "type &nbsp;".
+      "<span class='highlightKeys'>$keys</span>$morehelp";
+
+    return $result;
+  }


### PR DESCRIPTION
Adds support for the new 17.0 kps examples object, using `<kbd>` tags for the new format, and tweaks the layout slightly. Formatting changes are a stop-gap only before we move to a fully refreshed design.

![image](https://github.com/keymanapp/keymanweb.com/assets/4498365/ee8ecddd-6a79-4d4c-9dc2-8b7e73e413b6)


Fixes: #89