### PR TITLE
refactor: clean up KeymanHosts usage and make consistent

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 ## START STANDARD SITE BUILD SCRIPT INCLUDE
 readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly BOOTSTRAP="$(dirname "$THIS_SCRIPT")/resources/bootstrap.inc.sh"
-readonly BOOTSTRAP_VERSION=fix/keyman-hosts-for-server #v0.11
+readonly BOOTSTRAP_VERSION=v0.17
 [ -f "$BOOTSTRAP" ] && source "$BOOTSTRAP" || source <(curl -fs https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/bootstrap.inc.sh)
 ## END STANDARD SITE BUILD SCRIPT INCLUDE
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 ## START STANDARD SITE BUILD SCRIPT INCLUDE
 readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly BOOTSTRAP="$(dirname "$THIS_SCRIPT")/resources/bootstrap.inc.sh"
-readonly BOOTSTRAP_VERSION=v0.11
+readonly BOOTSTRAP_VERSION=fix/keyman-hosts-for-server #v0.11
 [ -f "$BOOTSTRAP" ] && source "$BOOTSTRAP" || source <(curl -fs https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/bootstrap.inc.sh)
 ## END STANDARD SITE BUILD SCRIPT INCLUDE
 

--- a/inc/servervars.php
+++ b/inc/servervars.php
@@ -36,12 +36,12 @@
     ".localhost" : "";
 
     // $site_protocol is used only by util.php at this time.
-  $TestServer = (KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_DEVELOPMENT) || 
+  $TestServer = (KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_DEVELOPMENT) ||
     (KeymanHosts::Instance()->Tier() == KeymanHosts::TIER_TEST) ? true : false;
   $site_protocol = $TestServer ? 'http://' : 'https://';
-    
+
   $url_keymanweb_res = KeymanHosts::Instance()->r_keymanweb_com;
-  $staticDomainRoot= KeymanHosts::Instance()->s_keyman_com;  
+  $staticDomainRoot= KeymanHosts::Instance()->s_keyman_com;
 
   $site_keymanwebhelp = KeymanHosts::Instance()->help_keyman_com;
   $site_keymanwebdemo = KeymanHosts::Instance()->keymanweb_com;
@@ -66,7 +66,7 @@
   // Uses official API for version checking, but is not optimized for
   // version-checking against multiple release tiers.
   function get_keymanweb_version($tier) {
-    $json = @file_get_contents(KeymanHosts::Instance()->api_keyman_com . "/version/web/$tier");
+    $json = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com . "/version/web/$tier");
     if($json) {
       $json = json_decode($json);
     }
@@ -81,7 +81,7 @@
   }
 
   function get_keymanweb_versions() {
-    $json = @file_get_contents(KeymanHosts::Instance()->api_keyman_com . "/version/web/all");
+    $json = @file_get_contents(KeymanHosts::Instance()->SERVER_api_keyman_com . "/version/web/all");
     if($json) {
       $json = json_decode($json);
     }

--- a/prog/renderLanguageExample.php
+++ b/prog/renderLanguageExample.php
@@ -22,7 +22,7 @@
 
   function renderLanguageExample($keyboard, $language) {
     $keyboard = str_replace('Keyboard_','',$keyboard);
-    $string = KeymanHosts::Instance()->api_keyman_com . "/keyboard/" . rawurlencode($keyboard);
+    $string = KeymanHosts::Instance()->SERVER_api_keyman_com . "/keyboard/" . rawurlencode($keyboard);
     $json = @file_get_contents($string);
     if($json === FALSE) {
       return FALSE;


### PR DESCRIPTION
* Splits the server-side and client-side references to keyman sites so that docker-based PHP can reference host.docker.internal on development machines for cross-references.

- [x] TODO: update to `BOOTSTRAP_VERSION=v0.17` in build.sh before merge.

Relates-to: keymanapp/shared-sites#53
Relates-to: keymanapp/keyman.com#545
Relates-to: keymanapp/api.keyman.com#272