### PR TITLE
chore: update sentry version, cleanup, and collect resource errors

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 ## START STANDARD SITE BUILD SCRIPT INCLUDE
 readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly BOOTSTRAP="$(dirname "$THIS_SCRIPT")/resources/bootstrap.inc.sh"
-readonly BOOTSTRAP_VERSION=v0.17
+readonly BOOTSTRAP_VERSION=feat/tier-name  # TODO v0.18
 [ -f "$BOOTSTRAP" ] && source "$BOOTSTRAP" || source <(curl -fs https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/bootstrap.inc.sh)
 ## END STANDARD SITE BUILD SCRIPT INCLUDE
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 ## START STANDARD SITE BUILD SCRIPT INCLUDE
 readonly THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
 readonly BOOTSTRAP="$(dirname "$THIS_SCRIPT")/resources/bootstrap.inc.sh"
-readonly BOOTSTRAP_VERSION=feat/tier-name  # TODO v0.18
+readonly BOOTSTRAP_VERSION=v0.18
 [ -f "$BOOTSTRAP" ] && source "$BOOTSTRAP" || source <(curl -fs https://raw.githubusercontent.com/keymanapp/shared-sites/$BOOTSTRAP_VERSION/bootstrap.inc.sh)
 ## END STANDARD SITE BUILD SCRIPT INCLUDE
 

--- a/cdn/dev/js/sentry.js
+++ b/cdn/dev/js/sentry.js
@@ -1,0 +1,76 @@
+(function initializeSentry() {
+  if(!window.Sentry) {
+    // Sentry scripts may have been blocked by client browser;
+    // we won't be reporting errors to Sentry, but we don't
+    // want to throw other errors
+    return;
+  }
+
+  //
+  // Tags all exceptions with the active KMW instance's metadata.
+  // Compare against the definition in the main repo:
+  // - keymanapp/keyman/common/core/web/tools/sentry-manager/src/index.ts
+  //
+  // Currently separate in part b/c we can't guarantee 14.0+ in order to use
+  // the generalized sentry-manager module yet; we allow users to specify older
+  // versions of KMW for use.  Also in part b/c keymanweb.com itself may produce errors.
+  //
+
+  const prepareEvent = function(event) {
+    // Make sure the metadata-generation function actually exists... (14.0+)
+    try {
+      if(window.keyman.getDebugInfo) {
+        event.extra = event.extra || {};
+        event.extra.keymanState = window.keyman.getDebugInfo();
+        event.extra.keymanHostPlatform = 'keymanweb.com';
+      }
+    } catch (ex) { /* Swallow any errors produced here */ }
+
+    return event;
+  };
+
+  //
+  // Initialize Sentry for this site
+  //
+
+  Sentry.init({
+    beforeSend: prepareEvent,
+    dsn: "https://11f513ea178d438e8f12836de7baa87d@o1005580.ingest.us.sentry.io/5983523",
+    release: sentryEnvironment.release,
+    integrations: [
+      Sentry.httpClientIntegration(),
+      Sentry.captureConsoleIntegration({
+        levels: ['error', 'warning']
+      })
+    ],
+    environment: sentryEnvironment.tier,
+  });
+
+  //
+  // Capture resource load errors
+  // per https://docs.sentry.io/platforms/javascript/troubleshooting/#capturing-resource-404s
+  //
+
+  window.addEventListener(
+    "error",
+    (event) => {
+      if (!event.target) return;
+
+      if (event.target.tagName === "IMG") {
+        Sentry.captureException(
+          new Error(`Failed to load image: ${event.target.src}`),
+        );
+      } else if (event.target.tagName === "LINK" && event.target.rel === "stylesheet") {
+        Sentry.captureException(
+          new Error(`Failed to load external stylesheet: ${event.target.href}`),
+        );
+      } else if (event.target.tagName === "SCRIPT") {
+        Sentry.captureException(
+          new Error(`Failed to load external script: ${event.target.src}`),
+        );
+      }
+    },
+    true, // useCapture - necessary for resource loading errors
+  );
+  console.log(`Sentry initialization complete: tier=${sentryEnvironment.tier}; release=${sentryEnvironment.release}`);
+})();

--- a/inc/head.php
+++ b/inc/head.php
@@ -57,70 +57,33 @@
 <title>KeymanWeb.com <?php if($tier != 'stable') echo "($tier)"; ?></title>
 
 <!-- note: using CDN and not bundle for now -->
+
 <script
-  src="https://browser.sentry-cdn.com/7.111.0/bundle.tracing.min.js"
-  integrity="sha384-zbLcy9H6obT3ZcKjGlb5Ai7vi4G0vXMLB1UU56WRyPJWarHEDeLOkuJ3HwR/7IDd"
+  src="https://js.sentry-cdn.com/bba22972ad6b4c2ab03a056f549cc23d.min.js"
   crossorigin="anonymous"
 ></script>
-  <script
-  src="https://browser.sentry-cdn.com/7.111.0/captureconsole.min.js"
-  integrity="sha384-29aW5YLMCGJnTd6js4VqwRHQk4lBe44qavgMQDtiMsXya0LpJqw5UqQDVyenw+SW"
-    crossorigin="anonymous"
+<script
+  src="https://browser.sentry-cdn.com/9.1.0/bundle.tracing.min.js"
+  integrity="sha384-MCeGoX8VPkitB3OcF9YprViry6xHPhBleDzXdwCqUvHJdrf7g0DjOGvrhIzpsyKp"
+  crossorigin="anonymous"
 ></script>
-
+<script
+  src="https://browser.sentry-cdn.com/9.1.0/captureconsole.min.js"
+  integrity="sha384-gkHY/HxnL+vrTN/Dn6S9siimRwqogMXpX4AetFSsf6X2LMQFsuXQGvIw7h2qWCt+"
+  crossorigin="anonymous"
+></script>
+<script
+  src="https://browser.sentry-cdn.com/9.1.0/httpclient.min.js"
+  integrity="sha384-ZsomH91NyAZy+YSYhJcpL3sSDFlkL310CJnpKNqL9KerB92RvfsH9tXRa2youKLM"
+  crossorigin="anonymous"
+></script>
 <script>
-  // Tags all exceptions with the active KMW instance's metadata.
-  // Compare against the definition in the main repo:
-  // - keymanapp/keyman/common/core/web/tools/sentry-manager/src/index.ts
-  //
-  // Currently separate in part b/c we can't guarantee 14.0+ in order to use
-  // the generalized sentry-manager module yet; we allow users to specify older
-  // versions of KMW for use.  Also in part b/c keymanweb.com itself may produce errors.
-  var prepareEvent = function(event) {
-    // Make sure the metadata-generation function actually exists... (14.0+)
-    try {
-      if(window.keyman.getDebugInfo) {
-        event.extra = event.extra || {};
-        event.extra.keymanState = window.keyman.getDebugInfo();
-        event.extra.keymanHostPlatform = 'keymanweb.com';
-      }
-    } catch (ex) { /* Swallow any errors produced here */ }
-
-    return event;
-  };
-
-<?php if($tier == 'stable') { ?>
-  var sentryRelease = "<?=$version?>";
-<?php } else { ?>
-  var sentryRelease = "<?=$version."-".$tier?>";
-<?php } ?>
-
-  // Note: not currently using js Loader as it does not seem to work correctly
-  // with integrations
-  doInitSentry();
-
-  function doInitSentry() {
-    if(!Sentry) {
-      // may be blocked by client
-      return;
-    }
-  Sentry.init({
-    beforeSend: prepareEvent,
-      dsn: "https://11f513ea178d438e8f12836de7baa87d@o1005580.ingest.us.sentry.io/5983523",
-    release: sentryRelease,
-      integrations: [
-        Sentry.captureConsoleIntegration({
-          levels: ['error', 'warning']
-        })
-      ],
-    environment:
-      // TODO: https://github.com/keymanapp/shared-sites/issues/13
-      ['www.keymanweb.com','keymanweb.com', 'web.keyman.com'].includes(location.host) ? 'production' :
-      ['web.keyman-staging.com'].includes(location.host) ? 'staging' :
-      'development',
-  });
+  const sentryEnvironment = {
+    tier: '<?=KeymanHosts::Instance()->TierName()?>',
+    release: '<?=$tier == 'stable' ? $kmwbuild : "$kmwbuild-$tier"?>',
   }
 </script>
+<script src="<?=cdn("js/sentry.js")?>"></script>
 
 <link rel='shortcut icon' href="<?php echo cdn("img/keymanweb-icon-16.png"); ?>">
 <link rel="stylesheet" type="text/css" href="<?php echo cdn("css/kmw.css"); ?>" />
@@ -220,16 +183,13 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.4/clipboard.js"></script>
 <script src="<?php echo "$url_keymanweb_res" ?>/code/bookmarklet_builder.js"></script>
 
-<script src="<?= $staticDomainRoot ?>/kmw/engine/<?php echo $kmwbuild; ?>/keymanweb.js"></script>
-<script src="<?= $staticDomainRoot ?>/kmw/engine/<?php echo $kmwbuild; ?>/kmwuitoolbar.js"></script>
-<!--
-<script src="http://localhost/keymanweb/release/unminified/web/keymanweb.js"></script>
-<script src="http://localhost/keymanweb/release/unminified/web/kmwuitoolbar.js"></script>
--->
+<script crossorigin="anonymous" src="<?= $staticDomainRoot ?>/kmw/engine/<?php echo $kmwbuild; ?>/keymanweb.js"></script>
+<script crossorigin="anonymous" src="<?= $staticDomainRoot ?>/kmw/engine/<?php echo $kmwbuild; ?>/kmwuitoolbar.js"></script>
 
 <script src="<?= cdn("js/jquery.zclip.js"); ?>"></script>
 <script src="<?= cdn("js/kmwlive.js"); ?>"></script>
 <script src="/prog/keyboards.php?tier=<?=$tier?>&amp;version=<?=$version?>"></script>
+
 <script>
   loadKeyboardFromHash();
   var pageLoading = true;


### PR DESCRIPTION
* Updates Sentry to 9.1.0
* Moves sentry initialization code into sentry.js
* Adds window.error handler to capture resource loading errors (e.g.
  script, link, img)

This change does not refactor to use the common KeymanSentry class, as that involves considerably more work, but it's a good stepping stone on the way to that eventually.

- [x] TODO: bootloader v0.18 in build.sh

Depends-on: keymanapp/shared-sites#54
Relates-to: #132