### PR TITLE
fix: properly handle paths in init-container.sh

### DIFF
--- a/resources/init-container.sh
+++ b/resources/init-container.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
+THIS_SCRIPT="$(readlink -f "${BASH_SOURCE[0]}")"
+THIS_SCRIPT_PATH="$(dirname "$THIS_SCRIPT")"
+
 if [[ ! $1 =~ "debug" ]]; then
     echo "---- Generating CDN ---"
-    cd ../cdn
+    cd "$THIS_SCRIPT_PATH/../cdn"
     php -d include_path=/var/www/html/_includes:. cdnrefresh.php
-    cd ..
-else 
+else
     echo "Skip Generating CDN and clean CDN cache"
-    rm -rf ../cdn/deploy
+    rm -rf "$THIS_SCRIPT_PATH/../cdn/deploy"
 fi


### PR DESCRIPTION
Allows CDN refresh to run on production, which called `resources/init-container.sh` instead of `./init-container.sh`.

Fixes: #135