### PR TITLE
fix: Disallow all bots since staging site doesn't need to be indexed

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,3 @@
-# Disallow all bots since we don't need anything idexed on the staging site
+# Disallow all bots since we don't need anything indexed on the staging site
 User-agent: *
 Disallow: /

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+# Disallow all bots since we don't need anything idexed on the staging site
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Similar to keymanapp/help.keyman.com#2013 on help.keyman-staging.com

This site previously didn't have a robots.txt file