### PR TITLE
maint: Update GitHub actions to Node 24

### DIFF
--- a/.github/workflows/add-to-keyman-project.yml
+++ b/.github/workflows/add-to-keyman-project.yml
@@ -13,6 +13,7 @@ jobs:
     name: Add new issues and pull requests to project
     runs-on: ubuntu-latest
     steps:
+      # TODO: Update to Node 24 when actions/add-to-project#712 is resolved
       - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/keymanapp/projects/1

--- a/.github/workflows/auto-approve-and-merge-keyman-server-pr.yml
+++ b/.github/workflows/auto-approve-and-merge-keyman-server-pr.yml
@@ -15,7 +15,7 @@ jobs:
     permissions: write-all
     steps:
     - name: Checkout
-      uses: actions/checkout@v4.1.5
+      uses: actions/checkout@v5.0.1
       with:
         sparse-checkout: |
           README.md

--- a/.github/workflows/auto-approve-and-merge-keyman-server-pr.yml
+++ b/.github/workflows/auto-approve-and-merge-keyman-server-pr.yml
@@ -15,7 +15,7 @@ jobs:
     permissions: write-all
     steps:
     - name: Checkout
-      uses: actions/checkout@v5.0.1
+      uses: actions/checkout@v6.0.2
       with:
         sparse-checkout: |
           README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3.5.2
+      uses: actions/checkout@v5.0.1
 
     # Build the docker image and create link to vendor/ dependencies
     - name: Build the Docker image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v5.0.1
+      uses: actions/checkout@v6.0.2
 
     # Build the docker image and create link to vendor/ dependencies
     - name: Build the Docker image

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,7 +9,8 @@ jobs:
     steps:
     - name: Update labels based on PR title
       id: labeler
-      uses: fuxingloh/multi-labeler@f5bd7323b53b0833c1e4ed8d7b797ae995ef75b4 # v2.0.1
+      # latest, but still Node 20
+      uses: fuxingloh/multi-labeler@b15a54460c38f54043fa75f7b08a0e2aa5b94b5b # v4.0.0
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         config-path: .github/multi-labeler.yml


### PR DESCRIPTION
Address keymanapp/keyman.com#682 for keymanweb.com

GHA to Node 24
* actions/checkout@v6.0.2

update GHA, but still Node 20
* fuxingloh/multi-labeler@b15a54460c38f54043fa75f7b08a0e2aa5b94b5b # v4.0.0

TODO when it gets updated to Node 24
* actions/add-to-project@v1.0.2

Test-bot: skip
