### PR TITLE
chore: update multi-labeler to 5.0.0

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,8 +9,7 @@ jobs:
     steps:
     - name: Update labels based on PR title
       id: labeler
-      # latest, but still Node 20
-      uses: fuxingloh/multi-labeler@b15a54460c38f54043fa75f7b08a0e2aa5b94b5b # v4.0.0
+      uses: fuxingloh/multi-labeler@bcd50af464202999e57f556b4aefcf05a34abf85 # v5.0.0
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         config-path: .github/multi-labeler.yml


### PR DESCRIPTION
This moves to node v24.

Relates-to: keymanapp/s.keyman.com#1607
Test-bot: skip